### PR TITLE
Fix/bug with sourcemaps

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
 var _ = require('lodash');
 
 var defaults,
+    isDebug,
     isDevelopment,
     noLocal;
 
@@ -19,12 +20,19 @@ defaults = {
             sass: './app/design/frontend/**/source/**/*.scss',
             images: './app/design/frontend/**/source/images/*'
         }
-    }
+    },
+    debug: false
 };
 
 // Command line argument to set development mode
 isDevelopment = process.argv.some(function (arg) {
     var re = /^\-\-(dev|development)$/;
+
+    return re.test(arg);
+});
+
+isDebug = process.argv.some(function (arg) {
+    var re = /^\-\-(debug)$/;
 
     return re.test(arg);
 });
@@ -59,6 +67,10 @@ module.exports = function (gulp, options) {
     // Set the mode to development, if required
     if (isDevelopment) {
         options.mode = 'development';
+    }
+
+    if (isDebug) {
+        options.debug = true;
     }
 
     require('./tasks/browser-sync')(gulp, options);

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "gulp-autoprefixer": "^3.0.2",
     "gulp-babel": "^6.1.2",
     "gulp-clean-css": "^2.0.7",
+    "gulp-debug": "^2.1.2",
     "gulp-empty": "^0.1.1",
     "gulp-if": "^2.0.1",
     "gulp-imagemin": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "gulp-babel": "^6.1.2",
     "gulp-clean-css": "^2.0.7",
     "gulp-empty": "^0.1.1",
+    "gulp-if": "^2.0.1",
     "gulp-imagemin": "^3.0.1",
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^2.3.1",

--- a/tasks/images.js
+++ b/tasks/images.js
@@ -3,7 +3,9 @@
 
 var _ = require('lodash'),
     imagemin = require('gulp-imagemin'),
-    rename = require('gulp-rename');
+    rename = require('gulp-rename'),
+    debug = require('gulp-debug'),
+    gulpIf = require('gulp-if');
 
 var imagesDefaults = {
     name: 'images'
@@ -19,6 +21,7 @@ module.exports = function (gulp, options) {
 
     gulp.task(imagesOptions.name, function () {
         return gulp.src(options.paths.src.images, {base: './'})
+            .pipe(gulpIf(options.debug, debug({title: imagesOptions.name})))
             .pipe(imagemin())
             .pipe(rename(function (path) {  // Replace the source paths with destination ones
                 path.dirname = path.dirname.replace(paths.dest.regex, paths.dest.replacement);

--- a/tasks/javascript.js
+++ b/tasks/javascript.js
@@ -8,6 +8,7 @@ var _ = require('lodash'),
     sourcemaps = require('gulp-sourcemaps'),
     babel = require('gulp-babel'),
     es2015 = require('babel-preset-es2015'),
+    debug = require('gulp-debug'),
     gulpIf = require('gulp-if');
 
 var javascriptDefaults = {
@@ -24,6 +25,7 @@ module.exports = function (gulp, options) {
 
     gulp.task(javascriptOptions.name, function () {
         return gulp.src(options.paths.src.js, {base: './'})
+        .pipe(gulpIf(options.debug, debug({title: javascriptOptions.name})))
         .pipe(gulpIf(options.mode === 'development', sourcemaps.init())) // Don't create sourcemaps in production
         .pipe(babel({
             presets: [es2015]

--- a/tasks/javascript.js
+++ b/tasks/javascript.js
@@ -3,12 +3,12 @@
 
 var _ = require('lodash'),
     browserSync = require('browser-sync'),
-    passthrough = require('gulp-empty'),
     rename = require('gulp-rename'),
     uglify = require('gulp-uglify'),    // Mangle and compress JavaScript
     sourcemaps = require('gulp-sourcemaps'),
     babel = require('gulp-babel'),
-    es2015 = require('babel-preset-es2015');
+    es2015 = require('babel-preset-es2015'),
+    gulpIf = require('gulp-if');
 
 var javascriptDefaults = {
     name: 'javascript'
@@ -22,31 +22,19 @@ module.exports = function (gulp, options) {
     // Set options
     _.merge(javascriptOptions, javascriptDefaults, options.javascript);
 
-    // Production / development specific changes
-    if (options.mode === 'development') {
-        // Don't uglify code in development
-        uglify = passthrough;
-    } else {
-        // Don't create sourcemaps in production
-        sourcemaps = {
-            init: passthrough,
-            write: passthrough
-        };
-    }
-
     gulp.task(javascriptOptions.name, function () {
         return gulp.src(options.paths.src.js, {base: './'})
-            .pipe(sourcemaps.init())
-	    .pipe(babel({
-                presets: [es2015]
-            }))
-            .pipe(uglify())
-            .pipe(rename(function (path) {  // Replace the source paths with destination ones
-                path.dirname = path.dirname.replace(paths.dest.regex, paths.dest.replacement);
-            }))
-            .pipe(sourcemaps.write())
-            .pipe(gulp.dest('./'))
-            .on('end', browserSync.reload);
+        .pipe(gulpIf(options.mode === 'development', sourcemaps.init())) // Don't create sourcemaps in production
+        .pipe(babel({
+            presets: [es2015]
+        }))
+        .pipe(gulpIf(options.mode !== 'development', uglify())) // Don't uglify code in development
+        .pipe(rename(function (path) {  // Replace the source paths with destination ones
+            path.dirname = path.dirname.replace(paths.dest.regex, paths.dest.replacement);
+        }))
+        .pipe(gulpIf(options.mode === 'development', sourcemaps.write())) // Don't create sourcemaps in production
+        .pipe(gulp.dest('./'))
+        .on('end', browserSync.reload);
     });
 
     gulp.task(javascriptOptions.name + ':watch', function () {


### PR DESCRIPTION
@phirunson Found a bug when running `gulp` without the `--dev` flag in that only the first 16 files in the source directory would be built into the web directory. When the `--dev` flag was enabled, then all files would be built across. I managed to track this down to being an issue with sourcemaps, so instead of using the passthrough to 'skip' the sourcemaps when running in production, the `gulp-if` plugin is used instead, allowing in-line conditional checks for running tasks.

I have also included a new plugin, `gulp-debug`, which is enabled by adding the parameter `--debug` when running gulp, which will give more information about which files are being included in each task.
